### PR TITLE
feature(change): user-to-mentor [finishes #167937315]

### DIFF
--- a/server/controllers/change.js
+++ b/server/controllers/change.js
@@ -1,0 +1,47 @@
+/* eslint-disable linebreak-style */
+/* eslint-disable import/no-unresolved */
+/* eslint-disable radix */
+/* eslint-disable object-curly-newline */
+import dotenv from 'dotenv';
+import jwt from 'jsonwebtoken';
+import users from '../models/users';
+
+dotenv.config();
+
+
+const change = (req, res) => {
+  const user = users.find(i => i.id === parseInt(req.params.id));
+
+  jwt.verify(req.token, process.env.THE_KEY, (err, theUser) => {
+    if (err) {
+      res.status(403).json({
+        status: 403,
+        error: 'auth failed',
+      });
+    } else if (theUser.position !== 'admin') {
+      res.status(403).json({
+        status: 403,
+        error: 'Access denied',
+      });
+    } else if (!user) {
+      res.status(404).json({
+        status: 404,
+        error: 'User ID not found',
+      });
+    } else if (user.position === 'admin' || user.position === 'mentor') {
+      res.status(401).json({
+        status: 401,
+        error: 'Must be users ID',
+      });
+    } else {
+      user.position = 'mentor';
+      users.push(user);
+      res.status(200).json({
+        status: 200,
+        user,
+      });
+    }
+  });
+};
+
+export default change;

--- a/server/router/router.js
+++ b/server/router/router.js
@@ -3,11 +3,16 @@
 /* eslint-disable spaced-comment */
 import express from 'express';
 import signup from '../controllers/signup';
+import change from '../controllers/change';
+import authent from '../middleware/authent';
 
 
 const router = express.Router();
 
 //For the signup
 router.post('/api/v1/auth/signup', signup);
+
+//for the patches
+router.patch('/api/v1/user/:userId', authent, change);
 
 export default router; 

--- a/server/tests/testChange.js
+++ b/server/tests/testChange.js
@@ -1,0 +1,90 @@
+/* eslint-disable linebreak-style */
+/* eslint-disable eol-last */
+/* eslint-disable no-unused-vars */
+/* eslint-disable indent */
+import { describe, it } from 'mocha';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../../app';
+
+chai.use(chaiHttp);
+chai.should();
+
+describe('Change User test', () => {
+    const tokenAdmin = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywiZmlyc3ROYW1lIjoiTkVOR08iLCJsYXN0TmFtZSI6IkFsbHkiLCJlbWFpbCI6ImFkbWluQGdtYWlsLmNvbSIsInBhc3N3b3JkIjoiJDJiJDEwJDJwOEhUVmwxMnF5bVU2bjh3bEs5Vi50SWE0ZEZrODMyMzE1M2pOcjdKQzJEYWlsVGJBMHZlIiwicG9zaXRpb24iOiJhZG1pbiIsImlhdCI6MTU2Njg5NjA3OH0.MWz3N8dU92NC2sTAml3n_FlBYBsEejdjGdkafrt2ozc';
+
+    const tokenAdminErr = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywiZmlyc3ROYW1lIjoiTkVOR08iLCJsYXN0TmFtZSI6IkFsbHkiLCJlbWFpbCI6ImFkbWluQGdtYWlsLmNvbSIsInBhc3N3b3JkIjoiJDJiJDEwJDJwOEhUVmwxMnF5bVU2bjh3bEs5Vi50SWE0ZEZrODMyMzE1M2pOcjdKQzJEYWlsVGJBMHZlIiwicG9zaXRpb24iOiJhZG1pbiIsImlhdCI6MTU2Njg5NjA3OH0.MWz3N8dU92NC2sTAml3n_FlBYBsEejdjGdkafrt2oz';
+
+    const tokenMentor = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZmlyc3ROYW1lIjoiUGF0cmljayIsImxhc3ROYW1lIjoiUmVueSIsImVtYWlsIjoicGF0b3NAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkcjNYcHg2MFNUaFBzdjUuUEpoeXJST0dZRFVYZDZxRlQzT0VqajMzdVdsbzdQWGU4MC9PYlciLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6ImRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoibWVudG9yIiwiaWF0IjoxNTY2ODkwNDk4fQ.eoxnYy8bAkpLFh6XJjdwIpgUhs2d3DLYzHZEjFNSu_s';
+
+    const tokenMentorErr = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZmlyc3ROYW1lIjoiUGF0cmljayIsImxhc3ROYW1lIjoiUmVueSIsImVtYWlsIjoicGF0b3NAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkcjNYcHg2MFNUaFBzdjUuUEpoeXJST0dZRFVYZDZxRlQzT0VqajMzdVdsbzdQWGU4MC9PYlciLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6ImRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoibWVudG9yIiwiaWF0IjoxNTY2ODkwNDk4fQ.eoxnYy8bAkpLFh6XJjdwIpgUhs2d3DLYzHZEjFNSu_';
+
+    const tokenUser = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoiTXVnaXNoYSIsImxhc3ROYW1lIjoiQm9yaXMiLCJlbWFpbCI6ImJvbmhldXJAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFM2VDFEVjQwdUdFNjN2LlFZUnovT242Uy5scVd6dFVDNkhDa2MwbHA3SndaY1lZYW8uSjIiLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6IkRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoidXNlciIsImlhdCI6MTU2Njg5MDU3NX0.P67BM0Gj4IeL54ovDiKeCwfXKBS1psWRxSW56P_020M';
+
+    const tokenUserErr = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoiTXVnaXNoYSIsImxhc3ROYW1lIjoiQm9yaXMiLCJlbWFpbCI6ImJvbmhldXJAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFM2VDFEVjQwdUdFNjN2LlFZUnovT242Uy5scVd6dFVDNkhDa2MwbHA3SndaY1lZYW8uSjIiLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6IkRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoidXNlciIsImlhdCI6MTU2Njg5MDU3NX0.P67BM0Gj4IeL54ovDiKeCwfXKBS1psWRxSW56P_020';
+
+      it('should check for token allowed token', (done) => {
+        chai.request(app)
+          .patch('/api/v1/user/1')
+          .set('authorization', tokenAdminErr)
+          .then((res) => {
+            res.body.status.should.be.equal(403);
+            done();
+          })
+          .catch(err => done(err));
+      });
+
+      it('should check if user Id exists', (done) => {
+        chai.request(app)
+          .patch('/api/v1/user/20')
+          .set('authorization', tokenAdmin)
+          .then((res) => {
+            res.body.status.should.be.equal(404);
+            done();
+          })
+          .catch(err => done(err));
+      });
+
+      it('should check for unauthorized', (done) => {
+        chai.request(app)
+          .patch('/api/v1/user/3')
+          .set('authorization', tokenAdmin)
+          .then((res) => {
+            res.body.status.should.be.equal(401);
+            done();
+          })
+          .catch(err => done(err));
+      });
+
+      it('should check for route access', (done) => {
+        chai.request(app)
+          .patch('/api/v1/user/1')
+          .set('authorization', tokenUser)
+          .then((res) => {
+            res.body.status.should.be.equal(403);
+            done();
+          })
+          .catch(err => done(err));
+      });
+
+      it('should check for token header', (done) => {
+        chai.request(app)
+          .patch('/api/v1/user/1')
+          .then((res) => {
+            res.body.status.should.be.equal(403);
+            done();
+          })
+          .catch(err => done(err));
+      });
+
+      it('should changer user to mentor', (done) => {
+        chai.request(app)
+          .patch('/api/v1/user/1')
+          .set('authorization', tokenAdmin)
+          .then((res) => {
+            res.body.status.should.be.equal(200);
+            done();
+          })
+          .catch(err => done(err));
+      });
+});


### PR DESCRIPTION
#### What does this PR do?

- Admin changes use to mentor

#### Description of Task to be completed?

- Creation of the endpoint which helps the admin to change user to mentor

#### How should this be manually tested?

- Admin login then runs the command `npm start` in the terminal, then open the postman and paste `http://localhost:4404/api/v1/user/:userId` by replacing `UserId` with the id of the user he/she to become a mentor in the web browser and putting the token in the header.

#### Any background context you want to provide?

- Run the command `npm test` in the terminal to see the test coverage 

#### What are the relevant pivotal tracker stories?

- `Admin should be able to change a user to a mentor #167937315`



