### PR TITLE
#167937301 Get a mentor by id

### DIFF
--- a/server/controllers/mentor.js
+++ b/server/controllers/mentor.js
@@ -1,0 +1,45 @@
+/* eslint-disable linebreak-style */
+/* eslint-disable import/no-unresolved */
+/* eslint-disable object-curly-newline */
+/* eslint-disable radix */
+import dotenv from 'dotenv';
+import jwt from 'jsonwebtoken';
+import users from '../models/users';
+
+
+dotenv.config();
+
+
+const getAMentor = (req, res) => {
+  const user = users.find(i => i.id === parseInt(req.params.id));
+  jwt.verify(req.token, process.env.THE_KEY, (err, theUser) => {
+    if (err) {
+      res.status(403).json({
+        status: 403,
+        error: 'auth failed',
+      });
+    } else if (theUser.position === 'mentor') {
+      res.status(403).json({
+        status: 403,
+        error: 'Access denied, not allowed',
+      });
+    } else if (!user) {
+      res.status(404).json({
+        status: 404,
+        error: 'User with the given ID does not exists',
+      });
+    } else if (user.position !== 'mentor') {
+      res.status(401).json({
+        status: 401,
+        error: 'The given ID is not mentor ID',
+      });
+    } else {
+      res.status(200).json({
+        status: 200,
+        user,
+      });
+    }
+  });
+};
+
+export default getAMentor;

--- a/server/router/router.js
+++ b/server/router/router.js
@@ -3,11 +3,16 @@
 /* eslint-disable spaced-comment */
 import express from 'express';
 import signup from '../controllers/signup';
+import getAMentor from '../controllers/mentor';
+import authent from '../middleware/authent';
 
 
 const router = express.Router();
 
 //For the signup
 router.post('/api/v1/auth/signup', signup);
+
+//for a mentor by id
+router.get('/api/v1/mentors/:mentorId', authent, getAMentor);
 
 export default router; 

--- a/server/tests/mentorTests.js
+++ b/server/tests/mentorTests.js
@@ -1,0 +1,90 @@
+/* eslint-disable linebreak-style */
+/* eslint-disable eol-last */
+/* eslint-disable no-unused-vars */
+/* eslint-disable indent */
+import { describe, it } from 'mocha';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../../app';
+
+
+chai.use(chaiHttp);
+chai.should();
+
+describe('/GET Specific Mentor', () => {
+    const tokenAdmin = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywiZmlyc3ROYW1lIjoiTkVOR08iLCJsYXN0TmFtZSI6IkFsbHkiLCJlbWFpbCI6ImFkbWluQGdtYWlsLmNvbSIsInBhc3N3b3JkIjoiJDJiJDEwJEhTa1RUQmw3TDl2V29ZRnN1bHpMeE9URWpjQS9XUTA5aEtBZU8uLmdYQjdDZllja1hTblEyIiwicG9zaXRpb24iOiJhZG1pbiIsImlhdCI6MTU2Njg5MDM0NX0.SXIZ2JIjV5BYk9IFBChgsJKe_TIHvjEFxbXbkUW3930';
+
+    const tokenAdminErr = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywiZmlyc3ROYW1lIjoiTkVOR08iLCJsYXN0TmFtZSI6IkFsbHkiLCJlbWFpbCI6ImFkbWluQGdtYWlsLmNvbSIsInBhc3N3b3JkIjoiJDJiJDEwJEhTa1RUQmw3TDl2V29ZRnN1bHpMeE9URWpjQS9XUTA5aEtBZU8uLmdYQjdDZllja1hTblEyIiwicG9zaXRpb24iOiJhZG1pbiIsImlhdCI6MTU2Njg5MDM0NX0.SXIZ2JIjV5BYk9IFBChgsJKe_TIHvjEFxbXbkUW393';
+
+    const tokenMentor = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZmlyc3ROYW1lIjoiUGF0cmljayIsImxhc3ROYW1lIjoiUmVueSIsImVtYWlsIjoicGF0b3NAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkcjNYcHg2MFNUaFBzdjUuUEpoeXJST0dZRFVYZDZxRlQzT0VqajMzdVdsbzdQWGU4MC9PYlciLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6ImRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoibWVudG9yIiwiaWF0IjoxNTY2ODkwNDk4fQ.eoxnYy8bAkpLFh6XJjdwIpgUhs2d3DLYzHZEjFNSu_s';
+
+    const tokenMentorErr = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZmlyc3ROYW1lIjoiUGF0cmljayIsImxhc3ROYW1lIjoiUmVueSIsImVtYWlsIjoicGF0b3NAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkcjNYcHg2MFNUaFBzdjUuUEpoeXJST0dZRFVYZDZxRlQzT0VqajMzdVdsbzdQWGU4MC9PYlciLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6ImRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoibWVudG9yIiwiaWF0IjoxNTY2ODkwNDk4fQ.eoxnYy8bAkpLFh6XJjdwIpgUhs2d3DLYzHZEjFNSu_';
+
+    const tokenUser = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoiTXVnaXNoYSIsImxhc3ROYW1lIjoiQm9yaXMiLCJlbWFpbCI6ImJvbmhldXJAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFM2VDFEVjQwdUdFNjN2LlFZUnovT242Uy5scVd6dFVDNkhDa2MwbHA3SndaY1lZYW8uSjIiLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6IkRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoidXNlciIsImlhdCI6MTU2Njg5MDU3NX0.P67BM0Gj4IeL54ovDiKeCwfXKBS1psWRxSW56P_020M';
+
+    const tokenUserErr = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoiTXVnaXNoYSIsImxhc3ROYW1lIjoiQm9yaXMiLCJlbWFpbCI6ImJvbmhldXJAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFM2VDFEVjQwdUdFNjN2LlFZUnovT242Uy5scVd6dFVDNkhDa2MwbHA3SndaY1lZYW8uSjIiLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6IkRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoidXNlciIsImlhdCI6MTU2Njg5MDU3NX0.P67BM0Gj4IeL54ovDiKeCwfXKBS1psWRxSW56P_020';
+
+    it('Err in auth', (done) => {
+        chai.request(app)
+        .get('/api/v1/mentors/1')
+        .then((res) => {
+            res.body.status.should.be.equal(403);
+        }).catch(err => done(err));
+        done();
+    });
+
+    it('Should check valid token', (done) => {
+        chai.request(app)
+        .get('/api/v1/mentors/1')
+        .set('authorization', tokenUserErr)
+        .then((res) => {
+            res.body.status.should.be.equal(403);
+        })
+        .catch(err => done(err));
+        done();
+    });
+
+    it('Should check route access', (done) => {
+        chai.request(app)
+        .get('/api/v1/mentors/1')
+        .set('authorization', tokenMentor)
+        .then((res) => {
+            res.body.status.should.be.equal(403);
+        })
+        .catch(err => done(err));
+        done();
+    });
+
+    it('Should check if ID exists', (done) => {
+        chai.request(app)
+        .get('/api/v1/mentors/20')
+        .set('authorization', tokenUser)
+        .then((res) => {
+            res.body.status.should.be.equal(404);
+        })
+        .catch(err => done(err));
+        done();
+    });
+
+    it('Should check Id if is mentor Id', (done) => {
+        chai.request(app)
+        .get('/api/v1/mentors/1')
+        .set('authorization', tokenUser)
+        .then((res) => {
+            res.body.status.should.be.equal(401);
+        })
+        .catch(err => done(err));
+        done();
+    });
+
+    it('Should view specific mentor', (done) => {
+        chai.request(app)
+        .get('/api/v1/mentors/2')
+        .set('authorization', tokenUser)
+        .then((res) => {
+            res.body.status.should.be.equal(200);
+        })
+        .catch(err => done(err));
+        done();
+    });
+});


### PR DESCRIPTION
#### What does this PR do?

-User or admin view a mentorby the id from the platform 

#### Description of Task to be completed?

- Creation of the endpoint which helps the user and the admin to view a mentor by id

#### How should this be manually tested?

-User or admin run the command `npm start` in the terminal, then open the postman and paste `http://localhost:4404/api/v1/mentor/mentorId` in the web browser, replace mentorId by the real one, paste the token in the header then send the request 

#### Any background context you want to provide?

- Run the command `npm test` in the terminal to see the test coverage 

#### What are the relevant pivotal tracker stories?

- `User should be able to see a specific mentor #167937301`
