### PR TITLE
#167937287 The mentor reject sessions from users

### DIFF
--- a/server/controllers/reject.js
+++ b/server/controllers/reject.js
@@ -1,0 +1,51 @@
+/* eslint-disable linebreak-style */
+/* eslint-disable radix */
+/* eslint-disable import/no-unresolved */
+/* eslint-disable object-curly-newline */
+import dotenv from 'dotenv';
+import jwt from 'jsonwebtoken';
+import sessions from '../models/sessions';
+
+dotenv.config();
+
+const reject = (req, res) => {
+  jwt.verify(req.token, process.env.THE_KEY, (err, theUser) => {
+    const session = sessions.find(c => c.id === parseInt(req.params.id));
+    if (err) {
+      res.status(403).json({
+        status: 403,
+        error: 'auth failed',
+      });
+    } else if (theUser.position !== 'mentor') {
+      res.status(403).json({
+        status: 403,
+        error: 'Access denied',
+      });
+    } else if (!session) {
+      res.status(404).json({
+        status: 404,
+        error: 'Session request not found',
+      });
+    } else if (theUser.id !== session.mentorId) {
+      res.status(401).json({
+        status: 401,
+        error: 'The given session Id does not match with mentor Id',
+      });
+    } else if (session.status === 'rejected') {
+      res.status(409).json({
+        status: 409,
+        error: 'The session request already rejected',
+      });
+    } else {
+      session.status = 'rejected';
+      res.status(200).json({
+        status: 200,
+        data: {
+          session,
+        },
+      });
+    }
+  });
+};
+
+export default reject;

--- a/server/router/router.js
+++ b/server/router/router.js
@@ -9,6 +9,7 @@ import authent from '../middleware/authent';
 import change from '../controllers/change';
 import signin from '../controllers/signin';
 import create from '../controllers/create';
+import reject from '../controllers/reject';
 
 const router = express.Router();
 
@@ -29,5 +30,8 @@ router.post('/api/v1/auth/signin', signin);
 
 //for the creation of the session
 router.post('/api/v1/sessions', authent, create);
+
+//for the mentor to reject the session
+router.patch('/api/v1/sessions/:sessionId/reject', authent, reject);
 
 export default router; 

--- a/server/tests/testReject.js
+++ b/server/tests/testReject.js
@@ -1,0 +1,100 @@
+/* eslint-disable linebreak-style */
+/* eslint-disable eol-last */
+/* eslint-disable no-unused-vars */
+/* eslint-disable indent */
+import { describe, it } from 'mocha';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../../app';
+
+chai.use(chaiHttp);
+chai.should();
+
+describe('/PATCH Reject user request', () => {
+    const tokenAdmin = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywiZmlyc3ROYW1lIjoiTkVOR08iLCJsYXN0TmFtZSI6IkFsbHkiLCJlbWFpbCI6ImFkbWluQGdtYWlsLmNvbSIsInBhc3N3b3JkIjoiJDJiJDEwJEhTa1RUQmw3TDl2V29ZRnN1bHpMeE9URWpjQS9XUTA5aEtBZU8uLmdYQjdDZllja1hTblEyIiwicG9zaXRpb24iOiJhZG1pbiIsImlhdCI6MTU2Njg5MDM0NX0.SXIZ2JIjV5BYk9IFBChgsJKe_TIHvjEFxbXbkUW3930';
+
+    const tokenAdminErr = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywiZmlyc3ROYW1lIjoiTkVOR08iLCJsYXN0TmFtZSI6IkFsbHkiLCJlbWFpbCI6ImFkbWluQGdtYWlsLmNvbSIsInBhc3N3b3JkIjoiJDJiJDEwJEhTa1RUQmw3TDl2V29ZRnN1bHpMeE9URWpjQS9XUTA5aEtBZU8uLmdYQjdDZllja1hTblEyIiwicG9zaXRpb24iOiJhZG1pbiIsImlhdCI6MTU2Njg5MDM0NX0.SXIZ2JIjV5BYk9IFBChgsJKe_TIHvjEFxbXbkUW393';
+
+    const tokenMentor = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZmlyc3ROYW1lIjoiUGF0cmljayIsImxhc3ROYW1lIjoiUmVueSIsImVtYWlsIjoicGF0b3NAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkcjNYcHg2MFNUaFBzdjUuUEpoeXJST0dZRFVYZDZxRlQzT0VqajMzdVdsbzdQWGU4MC9PYlciLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6ImRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoibWVudG9yIiwiaWF0IjoxNTY2ODkwNDk4fQ.eoxnYy8bAkpLFh6XJjdwIpgUhs2d3DLYzHZEjFNSu_s';
+
+    const tokenMentorErr = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZmlyc3ROYW1lIjoiUGF0cmljayIsImxhc3ROYW1lIjoiUmVueSIsImVtYWlsIjoicGF0b3NAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkcjNYcHg2MFNUaFBzdjUuUEpoeXJST0dZRFVYZDZxRlQzT0VqajMzdVdsbzdQWGU4MC9PYlciLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6ImRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoibWVudG9yIiwiaWF0IjoxNTY2ODkwNDk4fQ.eoxnYy8bAkpLFh6XJjdwIpgUhs2d3DLYzHZEjFNSu_';
+
+    const tokenUser = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoiTXVnaXNoYSIsImxhc3ROYW1lIjoiQm9yaXMiLCJlbWFpbCI6ImJvbmhldXJAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFM2VDFEVjQwdUdFNjN2LlFZUnovT242Uy5scVd6dFVDNkhDa2MwbHA3SndaY1lZYW8uSjIiLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6IkRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoidXNlciIsImlhdCI6MTU2Njg5MDU3NX0.P67BM0Gj4IeL54ovDiKeCwfXKBS1psWRxSW56P_020M';
+
+    const tokenUserErr = 'bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoiTXVnaXNoYSIsImxhc3ROYW1lIjoiQm9yaXMiLCJlbWFpbCI6ImJvbmhldXJAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFM2VDFEVjQwdUdFNjN2LlFZUnovT242Uy5scVd6dFVDNkhDa2MwbHA3SndaY1lZYW8uSjIiLCJiaW8iOiJUZWFjaGVyIiwib2NjdXBhdGlvbiI6IkRldmVsb3BlciIsImV4cGVydGlzZSI6IlB1YmxpYy1zcGVha2VyIiwiYWRkcmVzcyI6IlJ3YW5kYSIsInBvc2l0aW9uIjoidXNlciIsImlhdCI6MTU2Njg5MDU3NX0.P67BM0Gj4IeL54ovDiKeCwfXKBS1psWRxSW56P_020';
+
+    it('Err in auth', (done) => {
+        chai.request(app)
+        .patch('/api/v1/sessions/1/reject')
+        .then((res) => {
+            res.body.status.should.be.equal(403);
+        }).catch(err => done(err));
+        done();
+    });
+
+    it('Should check valid token', (done) => {
+        chai.request(app)
+        .patch('/api/v1/sessions/1/reject')
+        .set('authorization', tokenMentorErr)
+        .then((res) => {
+            res.body.status.should.be.equal(403);
+        })
+        .catch(err => done(err));
+        done();
+    });
+
+    it('Should check route access', (done) => {
+        chai.request(app)
+        .patch('/api/v1/sessions/1/reject')
+        .set('authorization', tokenUser)
+        .then((res) => {
+            res.body.status.should.be.equal(403);
+        })
+        .catch(err => done(err));
+        done();
+    });
+
+    it('Should check if session Id exists', (done) => {
+        chai.request(app)
+        .patch('/api/v1/sessions/10/reject')
+        .set('authorization', tokenMentor)
+        .then((res) => {
+            res.body.status.should.be.equal(404);
+        })
+        .catch(err => done(err));
+        done();
+    });
+
+    it('Should check if mentor Id in the session equal to mentor Id ', (done) => {
+        chai.request(app)
+        .patch('/api/v1/sessions/1/reject')
+        .set('authorization', tokenMentor)
+        .then((res) => {
+            res.body.status.should.be.equal(401);
+        })
+        .catch(err => done(err));
+        done();
+    });
+
+    it('Should check if session already rejected', (done) => {
+        chai.request(app)
+        .patch('/api/v1/sessions/4/reject')
+        .set('authorization', tokenMentor)
+        .then((res) => {
+            res.body.status.should.be.equal(409);
+        })
+        .catch(err => done(err));
+        done();
+    });
+
+    it('Should update status to rejected', (done) => {
+        chai.request(app)
+        .patch('/api/v1/sessions/2/reject')
+        .set('authorization', tokenMentor)
+        .then((res) => {
+            res.body.status.should.be.equal(200);
+        })
+        .catch(err => done(err));
+        done();
+    });
+});


### PR DESCRIPTION
#### What does this PR do?

- The mentor can reject a mentorship session on the platform from the users

#### Description of Task to be completed?

- Creation of the endpoint which helps the mentor to reject sessions from users

#### How should this be manually tested?

- The mentor run the command `npm start` in the terminal, then open the postman and paste, login then `http://localhost:4404/api/v1/sessions/:sessionId/reject` in the Url, replace the :sessionId by the id de wanted, paste the token in the header then send the request

#### Any background context you want to provide?

- Run the command `npm test` in the terminal to see the test coverage

#### What are the relevant pivotal tracker stories?

- Mentor should be able to reject a session #167937295